### PR TITLE
Fix missing reference to stop_client() in init.lua

### DIFF
--- a/lua/py_lsp/picker.lua
+++ b/lua/py_lsp/picker.lua
@@ -45,7 +45,7 @@ function M.find_vens_picker(opts, annotated_venvs, collected_venvs, run_func)
                 actions.close(prompt_bufnr)
                 local selection = action_state.get_selected_entry()
                 local selected_path = vim.tbl_keys(collected_venvs)[selection.index]
-                M.stop_client()
+                vim.lsp.stop_client()
 
                 run_func(selected_path, true)
             end)


### PR DESCRIPTION
I've been getting an error about a missing reference for `stop_client()` in the Telescope picker. I think it was a simple typo, so I've fixed it. For my purposes, the fix seems to work well.

However, there is a `M.stop_client()` in `init.lua` which from what I can tell looks to stop all clients attached to a buffer. It isn't used in all of the functions, so I stuck with the simple `vim.lsp.stop_client()`.