### PR TITLE
get_python_venv_name string expected got nil

### DIFF
--- a/lua/py_lsp/utils.lua
+++ b/lua/py_lsp/utils.lua
@@ -11,8 +11,11 @@ end
 
 -- This will probably break easily
 M.get_python_venv_name = function(venv_path)
-	venv_path = string.match(venv_path, "[a-zA-Z\\.0-9_-]+/bin/python")
-	return string.gsub(venv_path, "/bin/python", "")
+	if python_path ~= nil then
+		venv_path = string.match(venv_path, "[a-zA-Z\\.0-9_-]+/bin/python")
+		return string.gsub(venv_path, "/bin/python", "")
+	end
+	return "/bin/python"
 end
 
 M.has_lsp_installed_server = function(server_name)


### PR DESCRIPTION
This should fix the issue:

![image](https://github.com/HallerPatrick/py_lsp.nvim/assets/403283/df42c15f-e519-4834-b456-2d7fa3b8521c)
