### PR TITLE
on_init function takes python_path, not a venv_name

### DIFF
--- a/lua/py_lsp/init.lua
+++ b/lua/py_lsp/init.lua
@@ -88,7 +88,7 @@ local function run_lsp_server(venv_name)
   local on_init_fn
 
   if venv_name then
-    on_init_fn = on_init(venv_name)
+    on_init_fn = on_init(venv_name .. "/bin/python")
   else
     on_init_fn = build_on_init(option.get().source_strategies, option.get().default_venv_name)
   end

--- a/lua/py_lsp/init.lua
+++ b/lua/py_lsp/init.lua
@@ -88,7 +88,10 @@ local function run_lsp_server(venv_name)
   local on_init_fn
 
   if venv_name then
-    on_init_fn = on_init(venv_name .. "/bin/python")
+    if not string.match(venv_name, "bin/python") then
+			venv_name = venv_name .. "/bin/python"
+		end
+    on_init_fn = on_init(venv_name)
   else
     on_init_fn = build_on_init(option.get().source_strategies, option.get().default_venv_name)
   end

--- a/lua/py_lsp/init.lua
+++ b/lua/py_lsp/init.lua
@@ -89,8 +89,8 @@ local function run_lsp_server(venv_name)
 
   if venv_name then
     if not string.match(venv_name, "bin/python") then
-			venv_name = venv_name .. "/bin/python"
-		end
+      venv_name = venv_name .. "/bin/python"
+    end
     on_init_fn = on_init(venv_name)
   else
     on_init_fn = build_on_init(option.get().source_strategies, option.get().default_venv_name)


### PR DESCRIPTION

Without this patch venv is not activating for me by `:PyLspActivateVenv .venv `

This is related to #37 